### PR TITLE
Fix logger argument mismatches and chrono errors

### DIFF
--- a/include/cpp_project_template/logger.hpp
+++ b/include/cpp_project_template/logger.hpp
@@ -58,10 +58,28 @@ class Logger {
     void trace(std::string_view message);
 
     /**
+     * @brief Log a formatted message at trace level
+     * @tparam Args Variadic template arguments
+     * @param format The format string
+     * @param args The arguments to format
+     */
+    template <typename... Args>
+    void trace(fmt::format_string<Args...> format, Args&&... args);
+
+    /**
      * @brief Log a message at debug level
      * @param message The message to log
      */
     void debug(std::string_view message);
+
+    /**
+     * @brief Log a formatted message at debug level
+     * @tparam Args Variadic template arguments
+     * @param format The format string
+     * @param args The arguments to format
+     */
+    template <typename... Args>
+    void debug(fmt::format_string<Args...> format, Args&&... args);
 
     /**
      * @brief Log a message at info level
@@ -70,10 +88,28 @@ class Logger {
     void info(std::string_view message);
 
     /**
+     * @brief Log a formatted message at info level
+     * @tparam Args Variadic template arguments
+     * @param format The format string
+     * @param args The arguments to format
+     */
+    template <typename... Args>
+    void info(fmt::format_string<Args...> format, Args&&... args);
+
+    /**
      * @brief Log a message at warning level
      * @param message The message to log
      */
     void warning(std::string_view message);
+
+    /**
+     * @brief Log a formatted message at warning level
+     * @tparam Args Variadic template arguments
+     * @param format The format string
+     * @param args The arguments to format
+     */
+    template <typename... Args>
+    void warning(fmt::format_string<Args...> format, Args&&... args);
 
     /**
      * @brief Log a message at error level
@@ -82,10 +118,28 @@ class Logger {
     void error(std::string_view message);
 
     /**
+     * @brief Log a formatted message at error level
+     * @tparam Args Variadic template arguments
+     * @param format The format string
+     * @param args The arguments to format
+     */
+    template <typename... Args>
+    void error(fmt::format_string<Args...> format, Args&&... args);
+
+    /**
      * @brief Log a message at critical level
      * @param message The message to log
      */
     void critical(std::string_view message);
+
+    /**
+     * @brief Log a formatted message at critical level
+     * @tparam Args Variadic template arguments
+     * @param format The format string
+     * @param args The arguments to format
+     */
+    template <typename... Args>
+    void critical(fmt::format_string<Args...> format, Args&&... args);
 
     /**
      * @brief Format and log a message

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -89,6 +89,37 @@ void Logger::critical(std::string_view message) {
     }
 }
 
+// Template method implementations
+template <typename... Args>
+void Logger::trace(fmt::format_string<Args...> format, Args&&... args) {
+    log(Level::Trace, format, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void Logger::debug(fmt::format_string<Args...> format, Args&&... args) {
+    log(Level::Debug, format, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void Logger::info(fmt::format_string<Args...> format, Args&&... args) {
+    log(Level::Info, format, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void Logger::warning(fmt::format_string<Args...> format, Args&&... args) {
+    log(Level::Warning, format, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void Logger::error(fmt::format_string<Args...> format, Args&&... args) {
+    log(Level::Error, format, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void Logger::critical(fmt::format_string<Args...> format, Args&&... args) {
+    log(Level::Critical, format, std::forward<Args>(args)...);
+}
+
 template <typename... Args>
 void Logger::log(Level level, fmt::format_string<Args...> format, Args&&... args) {
     if (logger_) {
@@ -98,13 +129,69 @@ void Logger::log(Level level, fmt::format_string<Args...> format, Args&&... args
 }
 
 // Explicit instantiations for common use cases
+template void Logger::trace<int>(fmt::format_string<int>, int&&);
+template void Logger::trace<double>(fmt::format_string<double>, double&&);
+template void Logger::trace<std::string>(fmt::format_string<std::string>, std::string&&);
+template void Logger::trace<const char*>(fmt::format_string<const char*>, const char*&&);
+template void Logger::trace<std::string_view>(fmt::format_string<std::string_view>, std::string_view&&);
+template void Logger::trace<bool>(fmt::format_string<bool>, bool&&);
+
+template void Logger::debug<int>(fmt::format_string<int>, int&&);
+template void Logger::debug<double>(fmt::format_string<double>, double&&);
+template void Logger::debug<std::string>(fmt::format_string<std::string>, std::string&&);
+template void Logger::debug<const char*>(fmt::format_string<const char*>, const char*&&);
+template void Logger::debug<std::string_view>(fmt::format_string<std::string_view>, std::string_view&&);
+template void Logger::debug<bool>(fmt::format_string<bool>, bool&&);
+
+template void Logger::info<int>(fmt::format_string<int>, int&&);
+template void Logger::info<double>(fmt::format_string<double>, double&&);
+template void Logger::info<std::string>(fmt::format_string<std::string>, std::string&&);
+template void Logger::info<const char*>(fmt::format_string<const char*>, const char*&&);
+template void Logger::info<std::string_view>(fmt::format_string<std::string_view>, std::string_view&&);
+template void Logger::info<bool>(fmt::format_string<bool>, bool&&);
+template void Logger::info<size_t>(fmt::format_string<size_t>, size_t&&);
+
+template void Logger::warning<int>(fmt::format_string<int>, int&&);
+template void Logger::warning<double>(fmt::format_string<double>, double&&);
+template void Logger::warning<std::string>(fmt::format_string<std::string>, std::string&&);
+template void Logger::warning<const char*>(fmt::format_string<const char*>, const char*&&);
+template void Logger::warning<std::string_view>(fmt::format_string<std::string_view>, std::string_view&&);
+template void Logger::warning<bool>(fmt::format_string<bool>, bool&&);
+
+template void Logger::error<int>(fmt::format_string<int>, int&&);
+template void Logger::error<double>(fmt::format_string<double>, double&&);
+template void Logger::error<std::string>(fmt::format_string<std::string>, std::string&&);
+template void Logger::error<const char*>(fmt::format_string<const char*>, const char*&&);
+template void Logger::error<std::string_view>(fmt::format_string<std::string_view>, std::string_view&&);
+template void Logger::error<bool>(fmt::format_string<bool>, bool&&);
+
+template void Logger::critical<int>(fmt::format_string<int>, int&&);
+template void Logger::critical<double>(fmt::format_string<double>, double&&);
+template void Logger::critical<std::string>(fmt::format_string<std::string>, std::string&&);
+template void Logger::critical<const char*>(fmt::format_string<const char*>, const char*&&);
+template void Logger::critical<std::string_view>(fmt::format_string<std::string_view>, std::string_view&&);
+template void Logger::critical<bool>(fmt::format_string<bool>, bool&&);
+
 template void Logger::log<int>(Level, fmt::format_string<int>, int&&);
 template void Logger::log<double>(Level, fmt::format_string<double>, double&&);
 template void Logger::log<std::string>(Level, fmt::format_string<std::string>, std::string&&);
 template void Logger::log<const char*>(Level, fmt::format_string<const char*>, const char*&&);
-template void Logger::log<std::string_view>(Level, fmt::format_string<std::string_view>,
-                                            std::string_view&&);
+template void Logger::log<std::string_view>(Level, fmt::format_string<std::string_view>, std::string_view&&);
 template void Logger::log<bool>(Level, fmt::format_string<bool>, bool&&);
+template void Logger::log<size_t>(Level, fmt::format_string<size_t>, size_t&&);
+
+// Multi-argument templates for the cases in main.cpp
+template void Logger::debug<double, size_t>(fmt::format_string<double, size_t>, double&&, size_t&&);
+template void Logger::log<double, size_t>(Level, fmt::format_string<double, size_t>, double&&, size_t&&);
+
+// Additional instantiations for const references and lvalue references
+template void Logger::debug<const std::string&>(fmt::format_string<const std::string&>, const std::string&);
+template void Logger::debug<std::string&>(fmt::format_string<std::string&>, std::string&);
+template void Logger::info<const std::string&>(fmt::format_string<const std::string&>, const std::string&);
+template void Logger::info<std::string&>(fmt::format_string<std::string&>, std::string&);
+template void Logger::debug<const double&, size_t>(fmt::format_string<const double&, size_t>, const double&, size_t&&);
+template void Logger::info<const double&>(fmt::format_string<const double&>, const double&);
+template void Logger::info<int&>(fmt::format_string<int&>, int&);
 
 Logger& getGlobalLogger() {
     if (!g_logger) {

--- a/tests/test_logger_gtest.cpp
+++ b/tests/test_logger_gtest.cpp
@@ -3,6 +3,7 @@
 
 #include "cpp_project_template/logger.hpp"
 
+#include <chrono>
 #include <memory>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Resolve compilation errors by enabling formatted logging in `Logger` class and adding missing `<chrono>` header to tests.

---

[Open in Web](https://www.cursor.com/agents?id=bc-5c276100-9175-4824-9b5c-befd04f52dc3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5c276100-9175-4824-9b5c-befd04f52dc3)